### PR TITLE
Fix nuget package link version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Barcoded
 A C#/.NET library to generate barcode images.
 
-[![Nuget](https://img.shields.io/nuget/v/Barcoded)](https://www.nuget.org/packages/Barcoded/1.0.1)
+[![Nuget](https://img.shields.io/nuget/v/Barcoded)](https://www.nuget.org/packages/Barcoded/)
 [![Nuget](https://img.shields.io/nuget/dt/Barcoded)](https://www.nuget.org/packages/Barcoded/)
 ## Usage
 ```C#


### PR DESCRIPTION
Was linking to `1.0.1` specifically, even though the shield said `1.0.2`